### PR TITLE
Replace wildcard imports with explicit imports

### DIFF
--- a/ShowVerticalMetrics.glyphsReporter/Contents/Info.plist
+++ b/ShowVerticalMetrics.glyphsReporter/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>ShowVerticalMetrics</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.0.7</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright, Rainer Erich Scheichelbauer, 2017</string>
 	<key>NSPrincipalClass</key>

--- a/ShowVerticalMetrics.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowVerticalMetrics.glyphsReporter/Contents/Resources/plugin.py
@@ -13,8 +13,9 @@ from __future__ import division, print_function, unicode_literals
 ###########################################################################################################
 
 import objc
-from GlyphsApp import *
-from GlyphsApp.plugins import *
+from GlyphsApp import Glyphs
+from GlyphsApp.plugins import ReporterPlugin
+from AppKit import NSColor, NSBezierPath, NSAffineTransform, NSPoint
 
 class ShowVerticalMetrics(ReporterPlugin):
 	lowestGlyphName = None


### PR DESCRIPTION
Follows the recent import-cleanup pattern applied across the Glyphs plug-in repos: replace wildcard imports with explicit ones.

### Changes
- `from GlyphsApp import *` → `from GlyphsApp import Glyphs`
- `from GlyphsApp.plugins import *` → `from GlyphsApp.plugins import ReporterPlugin`
- Added `from AppKit import NSColor, NSBezierPath, NSAffineTransform, NSPoint` (previously reachable only via the wildcard)
- Version bump: `CFBundleVersion` 15 → 16, `CFBundleShortVersionString` 2.0.6 → 2.0.7

No behavioural change; only the imports are made explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2JtfNiM4z5Duepf74nqX)_